### PR TITLE
Remove from favorites fix

### DIFF
--- a/src/js/utils/local-storage.js
+++ b/src/js/utils/local-storage.js
@@ -11,6 +11,6 @@ export function AddToFavorites(exerciseID) {
 
 export function RemoveFromFavorites(exerciseID) {
     const favorites = JSON.parse(localStorage.getItem("favorites")) ?? [];
-    favorites.splice(favorites.indexOf(exerciseID));
+    favorites.splice(favorites.indexOf(exerciseID), 1);
     localStorage.setItem("favorites", JSON.stringify(favorites));
 }


### PR DESCRIPTION
In some  cases removing exercise from favorites results in the entire Array 'favorites' being cleared